### PR TITLE
Make email/phone required on submission

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -147,7 +147,7 @@
           </div>
           <div class="booking-form-group">
             <label for="booking-email">Email Address <span aria-hidden="true">*</span></label>
-            <input type="email" id="booking-email" name="email" placeholder="Enter your email" autocomplete="email" required/>
+            <input type="email" id="booking-email" name="email" placeholder="Enter your email" autocomplete="email"/>
             <span class="error-message" aria-live="polite" style="display: none;">Please enter a valid email
               address.</span>
           </div>
@@ -155,7 +155,7 @@
             <label for="booking-phone">Phone Number <span aria-hidden="true">*</span></label>
             <input type="tel" id="booking-phone" name="phone" placeholder="Enter your phone number"
               pattern="^\+?\d{10,15}$" title="Please enter a valid phone number (10 to 15 digits)."
-              autocomplete="tel" required/>
+              autocomplete="tel"/>
             <span class="error-message" aria-live="polite" style="display: none;">Please enter a valid phone
               number.</span>
           </div>

--- a/js/booking.js
+++ b/js/booking.js
@@ -307,7 +307,14 @@ class BookingForm {
 
   handleFormSubmit(e) {
     e.preventDefault();
-    if (this.validateFormStep(this.currentStep)) {
+    const emailInput = document.getElementById('booking-email');
+    const phoneInput = document.getElementById('booking-phone');
+    emailInput?.setAttribute('required', 'required');
+    phoneInput?.setAttribute('required', 'required');
+
+    const step1Valid = this.validateFormStep(1);
+    const currentValid = this.validateFormStep(this.currentStep);
+    if (step1Valid && currentValid) {
       this.updateFormData(this.currentStep);
       const submitBtn = document.querySelector('.booking-btn-submit');
       submitBtn.classList.add('loading');
@@ -328,6 +335,9 @@ class BookingForm {
           console.error('EmailJS Error:', err);
         });
     } else {
+      if (!step1Valid) {
+        this.goToStep(1);
+      }
       Toast.show('Please correct the errors on this step before submitting.', false);
     }
   }


### PR DESCRIPTION
## Summary
- remove `required` from booking form email and phone inputs
- enforce required email/phone validation only during form submission

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a29fbc0088320ac9f523a0e802b23