### PR TITLE
Add business address to footer

### DIFF
--- a/blogs.html
+++ b/blogs.html
@@ -140,6 +140,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>

--- a/blogs/10-cleaning-mistakes.html
+++ b/blogs/10-cleaning-mistakes.html
@@ -159,6 +159,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>

--- a/blogs/barrie-deep-cleaning.html
+++ b/blogs/barrie-deep-cleaning.html
@@ -163,6 +163,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>

--- a/blogs/declutter-your-space-declutter-your-mind.html
+++ b/blogs/declutter-your-space-declutter-your-mind.html
@@ -145,6 +145,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>

--- a/blogs/discover-cleaning-services.html
+++ b/blogs/discover-cleaning-services.html
@@ -237,6 +237,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>

--- a/blogs/office-cleaning-frequency.html
+++ b/blogs/office-cleaning-frequency.html
@@ -149,6 +149,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>

--- a/blogs/professional-cleaning-saves-you-money-time.html
+++ b/blogs/professional-cleaning-saves-you-money-time.html
@@ -155,6 +155,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>

--- a/booking.html
+++ b/booking.html
@@ -815,6 +815,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="/terms-of-service.html" id="openTermsModal" target="_blank" rel="noopener noreferrer">Terms of
           Service</a> •

--- a/css/footer.css
+++ b/css/footer.css
@@ -45,6 +45,16 @@
   outline-offset: 2px;
 }
 
+/* Footer Address */
+.footer-address {
+  font-size: 0.9rem;
+  color: var(--color-white);
+}
+
+.footer-address p {
+  margin-bottom: 0;
+}
+
 /* Footer Text */
 .footer p {
   font-size: 0.9rem;

--- a/index.html
+++ b/index.html
@@ -2543,6 +2543,7 @@
         <div class="footer-logo">
           <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
         </div>
+        <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
         <div class="footer-links">
           <a
             href="/terms-of-service.html"

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -7,6 +7,7 @@
     <link rel="canonical" href="https://zenzonecleaning.ca/privacy-policy.html" />
     <!-- Link to the project's utilities.css -->
     <link rel="stylesheet" href="/css/utilities.css" />
+    <link rel="stylesheet" href="/css/footer.css" />
     <style>
       /* Page-specific styling for the Privacy Policy page */
       .privacy-container {
@@ -196,6 +197,7 @@
     </main>
     <footer class="footer">
       <p>&copy; 2025 Zen Zone Cleaning Services. All rights reserved.</p>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
     </footer>
   </body>
 </html>

--- a/referral.html
+++ b/referral.html
@@ -66,6 +66,7 @@
       <div class="footer-logo">
         <p>&copy; 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="/terms-of-service.html" target="_blank" rel="noopener noreferrer">Terms of Service</a> •
         <a href="/privacy-policy.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a>

--- a/request.html
+++ b/request.html
@@ -166,6 +166,7 @@
         <div class="footer-logo">
           <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
         </div>
+        <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
         <div class="footer-links">
           <a
             href="/terms-of-service.html"

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -7,6 +7,7 @@
     <link rel="canonical" href="https://zenzonecleaning.ca/terms-of-service.html" />
     <!-- Link to the project's utilities.css -->
     <link rel="stylesheet" href="/css/utilities.css" />
+    <link rel="stylesheet" href="/css/footer.css" />
     <style>
       /* Page-specific styling for the Terms of Service page */
       .terms-container {
@@ -129,6 +130,7 @@
     </main>
     <footer class="footer">
       <p>&copy; 2025 Zen Zone Cleaning Services. All rights reserved.</p>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
     </footer>
   </body>
 </html>

--- a/thankyou.html
+++ b/thankyou.html
@@ -86,6 +86,7 @@
       <div class="footer-logo">
         <p>© 2025 Zen Zone Cleaning Services. All rights reserved.</p>
       </div>
+      <div class="footer-address"><p>49 High St 3rd floor, Barrie, ON L4N 5J4</p></div>
       <div class="footer-links">
         <a href="#" id="openTermsModal">Terms of Service</a> •
         <a href="#" id="openPrivacyModal">Privacy Policy</a>


### PR DESCRIPTION
## Summary
- display the company's street address in the footer on all site pages
- style the new address element via `footer-address` rules
- link footer stylesheet on policy pages for consistent styling
- update footer address to "49 High St 3rd floor, Barrie, ON L4N 5J4"

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689351c8a1d08320a2a1a0a6694c9a67